### PR TITLE
Pulling in docker-proxy as project dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
 
 version: 2
 jobs:
-  go-test:
+  go-test-controller:
     <<: *defaults
     steps:
       - checkout
@@ -17,7 +17,7 @@ jobs:
             go get github.com/tools/godep
             bash test.sh
 
-  build:
+  build-controller:
     working_directory: /go/src/github.com/opsforgeio/shipyard
     docker:
       - image: golang:1.8.5-jessie
@@ -39,7 +39,6 @@ jobs:
             chmod +x /usr/local/bin/docker
             rm -rf /tmp/docker*
             go get -v -d ./...
-            go get github.com/tools/godep
       - run:
           name: Build controller library
           command: |
@@ -51,7 +50,31 @@ jobs:
             - controller
             - static
 
-  dryrun:
+  build-proxy:
+    working_directory: /go/src/github.com/opsforgeio/shipyard
+    docker:
+      - image: golang:1.8.5-jessie
+    steps:
+      - checkout
+      - run:
+          name: Set up build environment
+          command: |
+            apt-get update
+            apt-get install -y wget curl gzip build-essential
+            apt-get clean
+            go get github.com/tools/godep
+      - run:
+          name: Build controller library
+          command: |
+            cd docker-proxy
+            go get -v -d ./...
+            make build
+      - persist_to_workspace:
+          root: docker-proxy
+          paths:
+            - docker-proxy
+
+  dryrun-controller:
     <<: *defaults
     steps:
       - checkout
@@ -64,7 +87,21 @@ jobs:
           command: |
             make image
 
-  deploy:
+  dryrun-proxy:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - attach_workspace:
+          at: docker-proxy
+      - run:
+          name: Build docker images
+          command: |
+            cd docker-proxy
+            make image
+
+  qc-controller:
     <<: *defaults
     steps:
       - checkout
@@ -73,10 +110,25 @@ jobs:
       - attach_workspace:
           at: controller
       - run:
-          name: Build and push docker images
+          name: Build and push docker image for controller
           command: |
             make image
-            make release
+            make testrelease
+
+  qc-proxy:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - attach_workspace:
+          at: docker-proxy
+      - run:
+          name: Build and push docker image for docker-proxy
+          command: |
+            cd docker-proxy
+            make image
+            make testrelease
 
   smoketest-convscript:
     <<: *defaults
@@ -87,7 +139,7 @@ jobs:
       - run:
           name: Deploying shipyard using wrapper script
           command: |
-            bash deploy/setup.sh
+            bash deploy/setup.sh qc
       - run:
           name: Using curl to verify shipyard accessibility on 8080
           command: |
@@ -109,7 +161,7 @@ jobs:
           name: Deploying shipyard using Docker Compose v3
           command: |
             cd deploy
-            bash launch.sh
+            bash launch.sh qc
       - run:
           name: Using curl to verify shipyard accessibility on 8080
           command: |
@@ -121,72 +173,94 @@ jobs:
           command: |
             docker run -ti --network=shipyard_shipyard curl -Lks http://shipyard_controller_1:8080 | grep -i 'ui-view' &>/dev/null
 
+  deploy-controller:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - attach_workspace:
+          at: controller
+      - run:
+          name: Build and push docker image for controller
+          command: |
+            make image
+            make release
+
+  deploy-proxy:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - attach_workspace:
+          at: docker-proxy
+      - run:
+          name: Build and push docker image for docker-proxy
+          command: |
+            cd docker-proxy
+            make image
+            make release
+
+
+
+
 workflows:
   version: 2
   shipyard-pipeline:
     jobs:
-      - go-test
-      - build:
+      # CODE TESTING STEPS
+      - go-test-controller
+      # BUILDING STEPS
+      - build-controller:
           requires:
-            - go-test
-      - dryrun:
+            - go-test-controller
+      - build-proxy
+      # INTEGRATION TESTING STEPS
+      - dryrun-controller:
           requires:
-            - build
-      - deploy:
-          filters:
-            branches:
-              only:
-                - master
+            - build-controller
+      - dryrun-proxy:
           requires:
-            - dryrun
+            - build-proxy
+      - qc-controller:
+          requires:
+            - dryrun-controller
+      - qc-proxy:
+          requires:
+            - dryrun-proxy
+      # ---- MASTER BRANCH ONLY ----
+      # SMOKE TESTING OF AUTOMATED DEPLOYMENTS
       - smoketest-convscript:
           filters:
             branches:
               only:
                 - master
           requires:
-            - deploy
+            - qc-controller
+            - qc-proxy
       - smoketest-compose3:
           filters:
             branches:
               only:
                 - master
           requires:
-            - deploy
-  shipyard-pipeline-nightly:
-    triggers:
-      - schedule:
-          cron: "6 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - go-test
-      - build:
-          requires:
-            - go-test
-      - dryrun:
-          requires:
-            - build
-      - deploy:
+            - qc-controller
+            - qc-proxy
+      # DEPLOYING NEW BASE IMAGES TO DOCKERHUB
+      - deploy-controller:
           filters:
             branches:
               only:
                 - master
           requires:
-            - dryrun
-      - smoketest-convscript:
+            - smoketest-convscript
+            - smoketest-compose3
+      - deploy-proxy:
           filters:
             branches:
               only:
                 - master
           requires:
-            - deploy
-      - smoketest-compose3:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - deploy
+            - smoketest-convscript
+            - smoketest-compose3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
   build-controller:
     working_directory: /go/src/github.com/opsforgeio/shipyard
     docker:
-      - image: golang:1.8.5-jessie
+      - image: golang:1.8-stretch
     steps:
       - checkout
       - run:
@@ -53,7 +53,7 @@ jobs:
   build-proxy:
     working_directory: /go/src/github.com/opsforgeio/shipyard
     docker:
-      - image: golang:1.8.5-jessie
+      - image: golang:1.8-stretch
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
           name: Build docker images
           command: |
             make image
+            make testimage
 
   dryrun-proxy:
     <<: *defaults
@@ -100,6 +101,7 @@ jobs:
           command: |
             cd docker-proxy
             make image
+            make testimage
 
   qc-controller:
     <<: *defaults
@@ -112,7 +114,7 @@ jobs:
       - run:
           name: Build and push docker image for controller
           command: |
-            make image
+            make testimage
             make testrelease
 
   qc-proxy:
@@ -127,7 +129,7 @@ jobs:
           name: Build and push docker image for docker-proxy
           command: |
             cd docker-proxy
-            make image
+            make testimage
             make testrelease
 
   smoketest-convscript:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: |
             curl -sL https://deb.nodesource.com/setup_9.x | bash -
             apt-get update
-            apt-get install -y nodejs wget curl gzip build-essential
+            apt-get install -y --allow-unauthenticated nodejs wget curl gzip build-essential
             apt-get clean
             npm install -g bower
             go get github.com/tools/godep
@@ -60,7 +60,7 @@ jobs:
           name: Set up build environment
           command: |
             apt-get update
-            apt-get install -y wget curl gzip build-essential
+            apt-get install -y --allow-unauthenticated wget curl gzip build-essential
             apt-get clean
             go get github.com/tools/godep
       - run:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ release:
 	@echo $(DOCKER_PASS) | docker login -u $(DOCKER_USER) --password-stdin
 	@docker push $(MAINT)/$(IMAGE):$(TAG)
 
+testrelease:
+	@echo $(DOCKER_PASS) | docker login -u $(DOCKER_USER) --password-stdin
+	@docker push $(MAINT)/$(IMAGE):test
+
 test: clean
 	@godep go test -v ./...
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ media:
 image:
 	@echo Building Shipyard image $(TAG)
 	@cd controller && docker build -t $(MAINT)/$(IMAGE):$(TAG) .
+testimage:
+	@echo Building Shipyard image test
+	@cd controller && docker build -t $(MAINT)/$(IMAGE):test .
 
 release:
 	@echo $(DOCKER_PASS) | docker login -u $(DOCKER_USER) --password-stdin

--- a/deploy/docker-compose-qc.yaml
+++ b/deploy/docker-compose-qc.yaml
@@ -23,7 +23,7 @@ services:
     depends_on:
       - discovery
     hostname: proxy
-    image: opsforge/docker-proxy:latest
+    image: opsforge/docker-proxy:test
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
@@ -60,7 +60,7 @@ services:
     depends_on:
       - swarm-agent
     hostname: shipyard-controller
-    image: opsforge/shipyard:latest
+    image: opsforge/shipyard:test
     command: |
       server
       -d tcp://swarm:3375

--- a/deploy/launch.sh
+++ b/deploy/launch.sh
@@ -3,8 +3,12 @@
 echo "
 Launching shipyard using compose v3...
 "
-
-docker-compose -p shipyard up -d
+if echo $1 | grep -i qc &>/dev/null ; then
+  echo "QC run identified, using QC compose file"
+  docker-compose -f docker-compose-qc.yaml -p shipyard up -d
+else
+  docker-compose -p shipyard up -d
+fi
 
 echo "
 Cluster launched and ready for access.

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -20,8 +20,13 @@ if [ -z "`which docker`" ]; then
     exit 1
 fi
 
+if echo $1 | grep -i qc &>/dev/null ; then
+    IMAGE=${IMAGE:-opsforge/shipyard:test}
+else
+    IMAGE=${IMAGE:-opsforge/shipyard:latest}
+fi
+
 ACTION=${ACTION:-deploy}
-IMAGE=${IMAGE:-opsforge/shipyard:latest}
 PREFIX=${PREFIX:-shipyard}
 SHIPYARD_ARGS=${SHIPYARD_ARGS:-""}
 TLS_CERT_PATH=${TLS_CERT_PATH:-}

--- a/docker-proxy/Dockerfile
+++ b/docker-proxy/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:16.04
+COPY docker-proxy /bin/docker-proxy
+ENTRYPOINT ["/bin/docker-proxy"]
+CMD ["-h"]

--- a/docker-proxy/Makefile
+++ b/docker-proxy/Makefile
@@ -21,6 +21,8 @@ build-static:
 
 image:
 	@docker build -t $(REPO):$(TAG) .
+testimage:
+	@docker build -t $(REPO):test .
 
 clean:
 	@rm docker-proxy

--- a/docker-proxy/Makefile
+++ b/docker-proxy/Makefile
@@ -1,0 +1,36 @@
+CGO_ENABLED=0
+GOOS=linux
+GOARCH=amd64
+COMMIT=`git rev-parse --short HEAD`
+APP?=docker-proxy
+REPO?=opsforge/$(APP)
+TAG?=latest
+export GO15VENDOREXPERIMENT=1
+
+all: build image
+
+add-deps:
+	@godep save
+	@rm -rf Godeps
+
+build:
+	@go build .
+
+build-static:
+	@go build -a -tags "netgo static_build" -installsuffix netgo .
+
+image:
+	@docker build -t $(REPO):$(TAG) .
+
+clean:
+	@rm docker-proxy
+
+testrelease:
+	@echo $(DOCKER_PASS) | docker login -u $(DOCKER_USER) --password-stdin
+	@docker push $(REPO):test
+
+release:
+	@echo $(DOCKER_PASS) | docker login -u $(DOCKER_USER) --password-stdin
+	@docker push $(REPO):$(TAG)
+
+.PHONY: build build-static image clean

--- a/docker-proxy/main.go
+++ b/docker-proxy/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"net"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	flDockerSocket       string
+	flListenAddr         string
+	flCertPath           string
+	flKeyPath            string
+	flDebug              bool
+	flInsecureSkipVerify bool
+)
+
+func init() {
+	flag.StringVar(&flDockerSocket, "d", "/var/run/docker.sock", "path to the Docker socket")
+	flag.StringVar(&flListenAddr, "l", ":2375", "listen address")
+	flag.StringVar(&flCertPath, "cert", "", "path to certificate")
+	flag.StringVar(&flKeyPath, "key", "", "path to certificate key")
+	flag.BoolVar(&flDebug, "D", false, "enable debug logging")
+	flag.BoolVar(&flInsecureSkipVerify, "i", false, "allow insecure communication")
+}
+
+func main() {
+	log.Info("docker proxy")
+	flag.Parse()
+
+	if flDebug {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		target := flDockerSocket
+
+		var c net.Conn
+
+		cl, err := net.Dial("unix", target)
+		if err != nil {
+			log.Errorf("error connecting to backend: %s", err)
+			return
+		}
+
+		c = cl
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijack error", 500)
+			return
+		}
+		nc, _, err := hj.Hijack()
+		if err != nil {
+			log.Printf("hijack error: %v", err)
+			return
+		}
+		defer nc.Close()
+		defer c.Close()
+
+		err = r.Write(c)
+		if err != nil {
+			log.Printf("error copying request to target: %v", err)
+			return
+		}
+
+		errc := make(chan error, 2)
+		cp := func(dst io.Writer, src io.Reader) {
+			_, err := io.Copy(dst, src)
+			errc <- err
+		}
+		go cp(c, nc)
+		go cp(nc, c)
+		<-errc
+	})
+
+	if flCertPath != "" && flKeyPath != "" {
+		log.Infof("Configuring TLS: cert=%s key=%s", flCertPath, flKeyPath)
+
+		log.Fatal(http.ListenAndServeTLS(flListenAddr, flCertPath, flKeyPath, handler))
+	} else {
+
+		log.Fatal(http.ListenAndServe(flListenAddr, handler))
+	}
+}

--- a/docker-proxy/readme.md
+++ b/docker-proxy/readme.md
@@ -1,0 +1,6 @@
+# Docker Proxy
+This is a simple Go app that proxies requests to a socket.  It is designed
+to provide proxy capabilities to the socket serving the Docker Remote API.
+
+# License
+MIT


### PR DESCRIPTION
Original design relies on the https://github.com/ehazlett/docker-proxy images to be pulled on launch. As that repo hasn't been updated for a while too, I'm adding the content as subfolder here and using the same pipeline to cover the CI / CD for that too.

Resulting image gets pushed to opsforge dockerhub repo too, so downstream compose and setup.sh refs have changed to reflect that.